### PR TITLE
update akka-stream-extensions to 0.10.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization in ThisBuild := "com.mfglabs"
 
 scalaVersion in ThisBuild := "2.11.7"
 
-version in ThisBuild := "0.9.0"
+version in ThisBuild := "0.10.0"
 
 resolvers in ThisBuild ++= Seq(
   "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",

--- a/core/src/main/scala/sqs/SQS.scala
+++ b/core/src/main/scala/sqs/SQS.scala
@@ -30,7 +30,7 @@ trait SQSStreamBuilder {
    * guarantee total message ordering.
    * @param messageSendingConcurrency
    */
-  def sendMessageAsStream(messageSendingConcurrency: Int = defaultMessageOpsConcurrency): Flow[SendMessageRequest, SendMessageResult, Unit] = {
+  def sendMessageAsStream(messageSendingConcurrency: Int = defaultMessageOpsConcurrency): Flow[SendMessageRequest, SendMessageResult, akka.NotUsed] = {
     Flow[SendMessageRequest].mapAsync(messageSendingConcurrency) { msg =>
       sqs.sendMessage(msg)
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object V {
     val awsJavaSDK        = "1.10.50"
     val pellucidAwsWrap   = "0.8.0"
-    val akkaStreamExt     = "0.9.0"
+    val akkaStreamExt     = "0.10.0"
     val scalaTest         = "2.2.1"
     val postgresDriver    = "9.3-1102-jdbc4"
     val grizzled          = "1.0.2"


### PR DESCRIPTION
* update brings project to use akka streams 2.4.x everywhere
  (previous 0.9.0 version dependned on akka-streams experimental 1.0, which is dead)

* internal-only changes that were necessary for akka streams 2.4.x update
  * most pervasive: replacement of `Unit` type with `akka.NotUsed` singleton
  * exact same functionality and semantics